### PR TITLE
fix: 少空格导致的跳转链接渲染异常

### DIFF
--- a/_posts/2022-10-30-better-bandwidth-management-with-ebpf-zh.md
+++ b/_posts/2022-10-30-better-bandwidth-management-with-ebpf-zh.md
@@ -283,7 +283,7 @@ netperf 压测。
 ## 4.1 BBR 基础
 
 > 完整 BBR 设计可参考
-> [<mark>(论文) BBR：基于拥塞（而非丢包）的拥塞控制（ACM, 2017）</mark>]({ % link _posts/2022-01-02-bbr-paper-zh.md % })。
+> [<mark>(论文) BBR：基于拥塞（而非丢包）的拥塞控制（ACM, 2017）</mark>]({ % link _posts/2022-01-02-bbr-paper-zh.md %})。
 > 译注。
 
 ### 4.1.1 设计初衷


### PR DESCRIPTION
[现网](http://arthurchiao.art/blog/better-bandwidth-management-with-ebpf-zh/#41-bbr-%E5%9F%BA%E7%A1%80)的效果如下：
```html
<a href="{ % link _posts/2022-01-02-bbr-paper-zh.md % }"><mark>(论文) BBR：基于拥塞（而非丢包）的拥塞控制（ACM, 2017）</mark></a>
```

本地没有配置jekyll环境，可以请您再测试一下。